### PR TITLE
fix jellyfish for its latest version

### DIFF
--- a/focus_app/focus.py
+++ b/focus_app/focus.py
@@ -97,7 +97,7 @@ def count_kmers(query_file, kmer_size, threads, kmer_order):
     output_dump = Path("kmer_dump_{}".format(suffix))
 
     # count and dump kmers counts
-    os.system("jellyfish count -m {} -o {} -s 100M -t {} -C --disk {}".format(kmer_size, output_count, threads,
+    os.system("jellyfish count -m {} -o {} -s 100M -t {} -C {}".format(kmer_size, output_count, threads,
                                                                               query_file))
     os.system("jellyfish dump {} -c > {}".format(output_count, output_dump))
 


### PR DESCRIPTION
--disk seems to be a problem on jellyfish >= 2.2.6 when running FOCUS with non-small files.

https://github.com/metageni/FOCUS/issues/21

This PR should fix it