### PR TITLE
fix minor bug

### DIFF
--- a/focus_app/focus_database_utils.py
+++ b/focus_app/focus_database_utils.py
@@ -32,7 +32,7 @@ def get_k_mer_count(genomes, kmer_size, threads, kmer_order):
     results = []
     with open(genomes) as f:
         for row in f:
-            row = row.strip().split()
+            row = row.strip().split("\t")
             metadata = row[:-1]
             query_file = row[-1]
 


### PR DESCRIPTION
Split metadata by "\t" in case user give a metadata file with spaces rather than `_`