### PR TITLE
Allowing either one or multiple fasta/q files

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,30 @@ line activates the newly created `focus` conda environment.
 
     example > focus -q samples_directory
 
+## Query
+
+The query can be one or more fasta or fastq files, or a directory containing those files. We filter for
+files that end `.fasta`, `.fastq`, or `.fna`, so please ensure any file that you want processed has one
+of those file extensions.
+
+You can provide a mixture of input files or directories, and we will filter the files as appropriate.
+
+For example:
+
+```bash
+focus -q fastq1.fastq -q fastq2.fastq -q directory/ -o output
+```
+
+will process the two fastq files `fastq1.fastq` and `fastq2.fastq` as well as any `fasta` or `fastq` files in `directory`
+and put the output in `output`.
+
+We currently do not handle `gzipped` or otherwise compressed input files.
+
+## Output
+FOCUS generates a tabular output per taxonomic level (`Kingdom`, `Phylum`, `Class`, `Order`, `Family`, `Genus`, `Species`, and `Strain`) and one with all levels which can be used as [STAMP](http://kiwi.cs.dal.ca/Software/STAMP)'s input for statistical analysis.
+
 ## Database
-New genoems can be added into the database by using command ``focus_database_utils``. 
+New genomes can be added into the database by using command ``focus_database_utils``. 
 
 It only requires a (``-g``) a tabular file (`\t`) as input with a genome per row where the columns are composed by the metadata
 of the genome on `Kingdom`, `Phylum`, `Class`, `Order`, `Family`, `Genus`, `Species`, `Strain`, and `path to FASTA file or the genome file`.
@@ -101,8 +123,6 @@ of the genome on `Kingdom`, `Phylum`, `Class`, `Order`, `Family`, `Genus`, `Spec
     
     example > focus_database_utils -m GENOMES_TABULAR_FILE
 
-## Output
-FOCUS generates a tabular output per taxonomic level (`Kingdom`, `Phylum`, `Class`, `Order`, `Family`, `Genus`, `Species`, and `Strain`) and one with all levels which can be used as [STAMP](http://kiwi.cs.dal.ca/Software/STAMP)'s input for statistical analysis.
 
 ## Citing
 FOCUS was written by Genivaldo G. Z. Silva. Feel free to [contact me](mailto:genivaldo.gueiros@gmail.com)


### PR DESCRIPTION
This PR overloads the `--query` option to allow any of

- a single fasta/q file
- multiple fasta/q files
- a directory of fasta/q files

You can now specify multiple fasta/q files independently rather than providing a directory with them.

e.g.

```
focus -q file1.fastq -q file2.fastq -q file3.fastq --ouput_directory output
```