### PR TITLE
Adding an alternative docker image

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,64 @@
+FROM --platform=linux/amd64 ubuntu:24.04
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+ARG LIBFABRIC_VERSION=1.21.0
+ARG UBUNTU_RELEASE=noble
+
+# Install required packages and dependencies
+RUN   apt -y update \
+      && apt -y install build-essential wget doxygen gnupg gnupg2 curl apt-transport-https software-properties-common  \
+      git vim gfortran libtool python3-venv ninja-build python3-pip \
+      libnuma-dev python3-dev slurm-client \
+      && apt -y remove --purge --auto-remove cmake \
+      && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null\
+      | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+      && apt-add-repository -y "deb https://apt.kitware.com/ubuntu/ ${UBUNTU_RELEASE} main" \
+      && apt -y update
+
+# Build and install libfabric
+RUN (if [ -e /tmp/build ]; then rm -rf /tmp/build; fi;) \
+      && mkdir -p /tmp/build \
+      && cd /tmp/build \
+      && wget https://github.com/ofiwg/libfabric/archive/refs/tags/v${LIBFABRIC_VERSION}.tar.gz \
+      && tar xf v${LIBFABRIC_VERSION}.tar.gz \
+      && cd libfabric-${LIBFABRIC_VERSION} \
+      && ./autogen.sh \
+      && ./configure \
+      && make -j 16 \
+      && make install
+
+#
+# Install miniforge
+#
+RUN set -eux ; \
+  curl -LO https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh ; \
+  bash ./Miniforge3-* -b -p /opt/miniforge3 -s ; \
+  rm -rf ./Miniforge3-*
+
+# create a directory so we can mount the remote /usr/bin e.g. for local slurm commands
+RUN mkdir /usr/remotebin
+ENV PATH /opt/miniforge3/bin:$PATH:/usr/remotebin
+#
+# Install conda environment
+#
+
+RUN pip install "numpy<2.0"
+RUN conda config --set channel_priority strict
+
+RUN mamba install --freeze-installed -n base -y -c conda-forge -c bioconda -c defaults focus 
+RUN mkdir -p /focus
+
+ENV PATH /opt/miniforge3/bin:$PATH
+RUN conda clean -af -y
+
+ARG SITE_PACKAGES=default_value
+
+# each RUN is in its own container, and so we need to create this variable and then share it for each run
+RUN SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])") && echo "SITE_PACKAGES=${SITE_PACKAGES}" > /tmp/site_packages
+RUN . /tmp/site_packages && cd ${SITE_PACKAGES}/focus_app/ && unzip db.zip && rm -f db.zip
+
+
+
+
+

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -1,0 +1,93 @@
+# Docker alternative
+
+This docker file creates a new ubuntu image and installs focus and extract the databases. Then there is a directory called `/focus` where you can mount your data.
+
+This image is particularly good for singularity!
+
+# Building this image
+
+### Cleaning up before you start
+
+> If you have been using docker recently, you might want to do a complete nuke
+> of the docker directory and start again. This is the easy way
+> and also updates docker!
+
+```
+sudo -H bash
+apt remove -y docker.io && rm -rf /var/lib/docker && apt install -y docker.io
+```
+
+### Remove any existing docker images
+
+```
+docker images
+docker images | awk '{print $3}' | grep -v IM | xargs docker rmi -f {}
+```
+
+### build a new image
+```
+docker build -t focus . > build.out 2> build.err
+```
+
+### tag it and upload to docker quay
+```
+docker login -u $USER
+TAG=37c06e3a9f8a     ## ADD THE BUILD MD5SUM here
+docker tag focus $USER/focus:v1.8.0_${TAG}
+
+docker push $USER/focus:v1.8.0_${TAG}
+```
+
+#  Running the image
+
+You can run the image to see what's there
+
+```
+docker run -i -t $USER/focus:v1.8.0_${TAG}  /bin/bash
+
+```
+
+
+
+# Running FOCUS with singularity
+
+We can use this dockerfile and convert it  into a `.sif` image.
+
+The current tag is d95c4fb1ae57
+
+# Load the singularity module and create a new image
+
+
+NOTE: There is (currently) an issue with singularity 4.1.0. If it persists, here is how to load a previous image:
+
+```
+module load pawseyenv/2023.08
+module load singularity/3.11.4-slurm
+```
+
+Otherwise, this will make a focus `.sif`
+
+```
+export TAG=d95c4fb1ae57
+module load singularity/4.1.0-slurm
+mkdir sif tmp
+# remember that singularity needs the full path (not a relative path, like tmp)
+export SINGULARITY_TMPDIR=$PWD/tmp/
+singularity pull --dir sif docker://$USER/focus:v1.8.0_${TAG}
+```
+
+Now, you need to link the directories so that everything will work.
+
+Assuming you have
+
+/home/edwa0468/Projects/focus
+/home/edwa0468/Projects/focus/fasta/
+
+Then this should work in a slurm job (see focus.slurm)
+
+```
+module load singularity/4.1.0-slurm
+
+singularity exec --bind /home/edwa0468/Projects/focus:/focus \
+        sif/focus:v1.8.0_${TAG} focus -q /focus/fasta -o /focus/focus -k 7
+```


### PR DESCRIPTION
This alternative dockerfile makes a complete `FOCUS` executable, including the databases, so that you can convert it into a singularity image, e.g. to run on a cluster.

There is a directory `/focus` that you can read/write for input/output